### PR TITLE
Style tweaks for localization dropdown

### DIFF
--- a/header.liquid
+++ b/header.liquid
@@ -570,6 +570,35 @@
       margin-top: calc(var(--header-height) * -1);
     }
   }
+
+  /* Consistent button spacing */
+  header-actions {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  /* Compact localization dropdown */
+  .localization-wrapper {
+    padding-inline: var(--padding-3xs);
+  }
+
+  .localization-wrapper .localization-form__select {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    height: 44px;
+  }
+
+  .localization-wrapper .localization-form__select img {
+    width: 20px;
+    height: 20px;
+  }
+
+  .localization-wrapper .localization-form__select span {
+    font-size: inherit;
+    font-weight: 400;
+    color: currentColor;
+  }
 {% endstylesheet %}
 
 {% schema %}


### PR DESCRIPTION
## Summary
- refine spacing between header buttons
- style localization dropdown for consistent icon scale and text

## Testing
- `echo "no tests"`

------
https://chatgpt.com/codex/tasks/task_e_686f8c0ca3a0832f843a609d5cbcc482