### PR TITLE
Fix localization rows default when none selected

### DIFF
--- a/header.liquid
+++ b/header.liquid
@@ -128,6 +128,9 @@
   endif
 
   assign bottom_row_blocks = bottom_row_blocks | split: ',' | compact
+  {% if bottom_row_blocks.size == 0 %}
+    {% assign rows = 'top' | split: ',' %}
+  {% endif %}
 
   if section.settings.section_height == 'compact'
     assign header_height_class = ' header--compact'

--- a/header.liquid
+++ b/header.liquid
@@ -128,9 +128,9 @@
   endif
 
   assign bottom_row_blocks = bottom_row_blocks | split: ',' | compact
-  {% if bottom_row_blocks.size == 0 %}
-    {% assign rows = 'top' | split: ',' %}
-  {% endif %}
+  if bottom_row_blocks.size == 0
+    assign rows = 'top' | split: ','
+  endif
 
   if section.settings.section_height == 'compact'
     assign header_height_class = ' header--compact'


### PR DESCRIPTION
## Summary
- adjust logic so header rows default to `top` when no blocks are selected for the bottom row

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fc0c17b70832f98dfd94614ff5506